### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,5 +1,8 @@
 name: Checkout PRs ✨
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Mr-MRF-Dev/Angry-Task/security/code-scanning/2](https://github.com/Mr-MRF-Dev/Angry-Task/security/code-scanning/2)

To fix this issue, the workflow should explicitly specify the minimal required permissions for the GITHUB_TOKEN. This is typically done by adding a `permissions` block, either at the root of the workflow or within each job. In this case, the job does not require write access to repository contents, issues, or pull requests. Only read access to repository contents is required for the checkout step and the CI/testing commands. Therefore, the best fix is to add a `permissions: contents: read` block at the root of the workflow (line 2 or 3), ensuring all jobs inherit this limited privilege. No other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
