### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     name: Build 🛠
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️


### PR DESCRIPTION
Potential fix for [https://github.com/Mr-MRF-Dev/Angry-Task/security/code-scanning/1](https://github.com/Mr-MRF-Dev/Angry-Task/security/code-scanning/1)

The best way to fix the problem is to add an explicit, restrictive `permissions` block to the `build` job in `.github/workflows/deploy.yml`. Since the build job only checks out code and uploads artifacts, it only needs read access to repository contents. You should edit the job configuration for `build` (starting on line 9) and insert `permissions:\n  contents: read` after `name:` and before `runs-on:` (ideally after line 10). No imports or other definitions are required, since this is a YAML configuration file for GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
